### PR TITLE
fixed a compatibility problem in query function

### DIFF
--- a/score/es/_init.py
+++ b/score/es/_init.py
@@ -258,7 +258,7 @@ class ConfiguredEsModule(ConfiguredModule):
         if isinstance(query, str):
             kwargs['q'] = query
         else:
-            kwargs['body'] = query
+            kwargs['body'] = {'query': query}
         # TODO: use the session of a ctx object instead of creating a new
         #   session here!
         session = self.db.Session()


### PR DESCRIPTION
on version 0.2.3 backwards compatibility is broken, this small change should fix the behavior, it is also possible to check the query dict for the key 'query' and only execute the changeset if 'query' is not a key of query dict.
